### PR TITLE
Release v2.1.0 - PHP 8.3 & PHP 8.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,25 +10,45 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: [ '8.1', '8.2', '8.3' ]
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # To avoid "Shallow clone detected" error in SonarCloud report
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Cache Composer dependencies
-        id: composer-cache
-        uses: actions/cache@v3
+      #~ PHP Setup
+      - name: Setup PHP ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v2
         with:
-          path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+          php-version: ${{ matrix.php-versions }}
+
+      #~ Composer Cache
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      #~ Composer install
+      - name: Validate composer.json
+        run: composer validate
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: make install
+
+      #~ CI part
+      - name: Dependencies
+        run: make deps
 
       - name: Check Code Style
         run: make phpcs
@@ -41,17 +61,17 @@ jobs:
           sed -i 's+'$GITHUB_WORKSPACE'+/github/workspace+g' build/reports/phpunit/clover.xml
           sed -i 's+'$GITHUB_WORKSPACE'+/github/workspace+g' build/reports/phpunit/unit.xml
 
-      - name: PHP 8.1 Compatibility
-        run: make php81compatibility
+      - name: PHP min compatibility
+        run: make php-min-compatibility
 
-      - name: PHP 8.2 Compatibility
-        run: make php82compatibility
+      - name: PHP max compatibility
+        run: make php-max-compatibility
 
       - name: PHP Static Analyze
         run: make analyze
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v1.7
+        uses: SonarSource/sonarcloud-github-action@v2.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN:  ${{ secrets.SONAR_TOKEN }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,24 @@
+<?php
+
+return (new PhpCsFixer\Config())
+    //~ Rules
+    ->setRules(
+        [
+            '@PER-CS2.0' => true,
+        ]
+    )
+
+    //~ Format
+    ->setFormat('txt')
+
+    //~ Cache
+    ->setUsingCache(true)
+    ->setCacheFile(__DIR__ . '/build/.php-cs-fixer.cache')
+
+    //~ Finder
+    ->setFinder((new PhpCsFixer\Finder())->in(
+        [
+            __DIR__ . '/src',
+            __DIR__ . '/tests',
+        ]))
+;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ```yaml
 ## [tag] - YYYY-MM-DD
-[tag]: https://github.com/eureka-framework/component-serializer/compare/2.0.0...master
+[tag]: https://github.com/eureka-framework/component-serializer/compare/2.1.0...master
 ### Changed
 - Change 1
 ### Added
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ```
 
 ----
+
+## [2.1.0] - 2024-08-22
+[2.1.0]: https://github.com/eureka-framework/component-serializer/compare/2.0.0...2.1.0
+### Changed
+- Now support PHP 8.3 & PHP 8.4
+- Fix some code style
+- Use `\` for functions from global namespace
+- Replace PHPCS by php-cs-fixer
+- Move unit test to subdirectory `unit/`
+- Dev dependencies update
+- Update CI workflow
+- Update Makefile & Readme
 
 ## [2.0.0] - 2023-03-20
 [2.0.0]: https://github.com/eureka-framework/component-serializer/compare/1.0.0...2.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,47 @@
-.PHONY: validate install update phpcs phpcbf php81compatibility php82compatibility phpstan analyze tests testdox ci clean
+.PHONY: validate install update phpcs phpcbf phpmincompatibility phpmaxcompatibility phpstan analyze tests testdox ci clean
+
+PHP_MIN_VERSION := "8.1"
+PHP_MAX_VERSION := "8.3"
+COMPOSER_BIN := composer
+
+ifneq (,$(wildcard ./.env))
+	include .env
+	export
+endif
 
 define header =
     @if [ -t 1 ]; then printf "\n\e[37m\e[100m  \e[104m $(1) \e[0m\n"; else printf "\n### $(1)\n"; fi
 endef
 
 #~ Composer dependency
+build: generator phpcsf
+
+generator:
+	$(call header,"Build new version of client, formatter & VO")
+	@./bin/script generator --file="./data/openapi.json" --debug
+
+#~ Composer dependency
 validate:
 	$(call header,Composer Validation)
-	@composer validate
+	@${COMPOSER_BIN} validate
 
 install:
 	$(call header,Composer Install)
-	@composer install
+	@${COMPOSER_BIN} install
 
 update:
 	$(call header,Composer Update)
-	@composer update
+	@${COMPOSER_BIN} update
+	@${COMPOSER_BIN} bump --dev-only
+
+outdated:
+	$(call header,Composer Outdated)
+	@${COMPOSER_BIN} outdated --direct
 
 composer.lock: install
 
 #~ Vendor binaries dependencies
-vendor/bin/phpcbf:
-vendor/bin/phpcs:
+vendor/bin/php-cs-fixer:
 vendor/bin/phpstan:
 vendor/bin/phpunit:
 
@@ -29,47 +49,53 @@ vendor/bin/phpunit:
 build/reports/phpunit:
 	@mkdir -p build/reports/phpunit
 
-build/reports/phpcs:
-	@mkdir -p build/reports/cs
-
 build/reports/phpstan:
 	@mkdir -p build/reports/phpstan
 
 #~ main commands
-phpcs: vendor/bin/phpcs build/reports/phpcs
+deps: composer.json # jenkins + manual
+	$(call header,Checking Dependencies)
+	@XDEBUG_MODE=off ./vendor/bin/composer-dependency-analyser --config=./ci/composer-dependency-analyser.php # for shadow & unused required dependencies
+	@XDEBUG_MODE=off ./vendor/bin/composer-require-checker check # mainly for ext-* missing dependencies
+
+phpcs: vendor/bin/php-cs-fixer # jenkins + manual
 	$(call header,Checking Code Style)
-	@./vendor/bin/phpcs --standard=./ci/phpcs/eureka.xml --cache=./build/cs_eureka.cache -p --report-full --report-checkstyle=./build/reports/cs/eureka.xml src/ tests/
+	@XDEBUG_MODE=off ./vendor/bin/php-cs-fixer check -v --diff
 
-phpcbf: vendor/bin/phpcbf
+phpcsf: vendor/bin/php-cs-fixer # manual
 	$(call header,Fixing Code Style)
-	@./vendor/bin/phpcbf --standard=./ci/phpcs/eureka.xml src/ tests/
+	@XDEBUG_MODE=off ./vendor/bin/php-cs-fixer fix -v
 
-php81compatibility: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Checking PHP 8.1 compatibility)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php81-compatibility.neon --error-format=table
+php-min-compatibility: vendor/bin/phpstan build/reports/phpstan # jenkins + manual
+	$(call header,Checking PHP $(PHP_MIN_VERSION) compatibility)
+	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php-min-compatibility.neon --error-format=table
 
-php82compatibility: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Checking PHP 8.2 compatibility)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php82-compatibility.neon --error-format=table
+php-max-compatibility: vendor/bin/phpstan build/reports/phpstan # jenkins + manual
+	$(call header,Checking PHP $(PHP_MAX_VERSION) compatibility)
+	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php-max-compatibility.neon --error-format=table
 
-analyze: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Running Static Analyze - Pretty tty format)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --error-format=table
-
-phpstan: vendor/bin/phpstan build/reports/phpstan
+phpstan: vendor/bin/phpstan build/reports/phpstan # jenkins
 	$(call header,Running Static Analyze)
 	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --error-format=checkstyle > ./build/reports/phpstan/phpstan.xml
 
-tests: vendor/bin/phpunit build/reports/phpunit
+analyze: vendor/bin/phpstan build/reports/phpstan # manual
+	$(call header,Running Static Analyze - Pretty tty format)
+	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --error-format=table
+
+tests: vendor/bin/phpunit build/reports/phpunit # jenkins + manual
 	$(call header,Running Unit Tests)
-	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-clover=./build/reports/phpunit/clover.xml --log-junit=./build/reports/phpunit/unit.xml --coverage-php=./build/reports/phpunit/unit.cov --coverage-html=./build/reports/coverage/ --fail-on-warning
+	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --testsuite=unit --coverage-clover=./build/reports/phpunit/clover.xml --log-junit=./build/reports/phpunit/unit.xml --coverage-php=./build/reports/phpunit/unit.cov --coverage-html=./build/reports/coverage/ --fail-on-warning
 
-testdox: vendor/bin/phpunit $(PHP_FILES)
+integration: vendor/bin/phpunit build/reports/phpunit # manual
+	$(call header,Running Integration Tests)
+	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --testsuite=integration --fail-on-warning
+
+testdox: vendor/bin/phpunit # manual
 	$(call header,Running Unit Tests (Pretty format))
-	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --fail-on-warning --testdox
+	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --testsuite=unit --fail-on-warning --testdox
 
-clean:
+clean: # manual
 	$(call header,Cleaning previous build)
 	@if [ "$(shell ls -A ./build)" ]; then rm -rf ./build/*; fi; echo " done"
 
-ci: clean validate install phpcs tests php81compatibility php82compatibility analyze
+ci: clean validate deps phpcs tests php-min-compatibility php-max-compatibility analyze

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # component-serializer
 [![Current version](https://img.shields.io/packagist/v/eureka/component-serializer.svg?logo=composer)](https://packagist.org/packages/eureka/component-serializer)
-[![Supported PHP version](https://img.shields.io/static/v1?logo=php&label=PHP&message=8.1%20-%208.2&color=777bb4)](https://packagist.org/packages/eureka/component-serializer)
+[![Supported PHP version](https://img.shields.io/static/v1?logo=php&label=PHP&message=8.1%20-%208.4&color=777bb4)](https://packagist.org/packages/eureka/component-serializer)
 ![CI](https://github.com/eureka-framework/component-serializer/workflows/CI/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=eureka-framework_component-serializer&metric=alert_status)](https://sonarcloud.io/dashboard?id=eureka-framework_component-serializer)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=eureka-framework_component-serializer&metric=coverage)](https://sonarcloud.io/dashboard?id=eureka-framework_component-serializer)
@@ -222,6 +222,11 @@ You can run tests (with coverage) on your side with following command:
 make tests
 ```
 
+You can run tests (with coverage) on your side with following command:
+```bash
+make integration
+```
+
 For prettier output (but without coverage), you can use the following command:
 ```bash
 make testdox # run tests without coverage reports but with prettified output
@@ -235,7 +240,7 @@ make phpcs
 
 You also can run code style fixes with following commands:
 ```bash
-make phpcbf
+make phpcsf
 ```
 
 #### Static Analysis
@@ -246,12 +251,12 @@ make analyze
 
 Minimal supported version:
 ```bash
-make php81compatibility
+make php-min-compatibility
 ```
 
 Maximal supported version:
 ```bash
-make php82compatibility
+make php-max-compatibility
 ```
 
 #### CI Simulation

--- a/ci/composer-dependency-analyser.php
+++ b/ci/composer-dependency-analyser.php
@@ -1,0 +1,10 @@
+<?php
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+
+$config = new Configuration();
+
+return $config
+    ->addPathToScan(__DIR__ . '/../src', isDev: false)
+    ->addPathToScan(__DIR__ . '/../tests', isDev: true)
+;

--- a/ci/php-max-compatibility.neon
+++ b/ci/php-max-compatibility.neon
@@ -1,0 +1,10 @@
+includes:
+  - ./../vendor/phpstan/phpstan-phpunit/extension.neon
+  - ./../vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+  phpVersion: 80300
+  level: 0
+  paths:
+    - ./../src
+    - ./../tests

--- a/ci/php-min-compatibility.neon
+++ b/ci/php-min-compatibility.neon
@@ -1,0 +1,10 @@
+includes:
+  - ./../vendor/phpstan/phpstan-phpunit/extension.neon
+  - ./../vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+  phpVersion: 80100
+  level: 0
+  paths:
+    - ./../src
+    - ./../tests

--- a/ci/php81-compatibility.neon
+++ b/ci/php81-compatibility.neon
@@ -1,9 +1,0 @@
-parameters:
-  phpVersion: 80100 # PHP 8.1
-  level: 0
-  paths:
-    - ./../src
-    - ./../tests
-
-  bootstrapFiles:
-    - ./../vendor/autoload.php

--- a/ci/php82-compatibility.neon
+++ b/ci/php82-compatibility.neon
@@ -1,9 +1,0 @@
-parameters:
-  phpVersion: 80200 # PHP 8.2
-  level: 0
-  paths:
-    - ./../src
-    - ./../tests
-
-  bootstrapFiles:
-    - ./../vendor/autoload.php

--- a/ci/phpcs/eureka.xml
+++ b/ci/phpcs/eureka.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<ruleset name="eureka">
-    <description>The coding standard for Eureka.</description>
-
-    <arg value="nps"/>
-
-    <rule ref="PSR12"/>
-</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "eureka/component-serializer",
-  "description": "Template for new component & domain",
+  "description": "Serializer used in client to serialize response VO when they are put in cache.",
   "type": "library",
   "minimum-stability": "stable",
   "license": "MIT",
@@ -19,27 +19,27 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Eureka\\Component\\Serializer\\Tests\\": "./tests"
+      "Eureka\\Component\\Serializer\\Tests\\Unit\\": "./tests/unit",
+      "Eureka\\Component\\Serializer\\Tests\\Integration\\": "./tests/integration"
     }
   },
 
   "config": {
-    "sort-packages": true,
-    "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
-    }
+    "sort-packages": true
   },
 
   "require": {
-    "php": "8.1.*||8.2.*",
+    "php": "8.1.*||8.2.*||8.3.*||8.4.*",
     "ext-json": "*"
   },
 
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-    "phpstan/phpstan": "^1.10",
-    "phpunit/phpcov": "^8.2",
-    "phpunit/phpunit": "^9.6",
-    "squizlabs/php_codesniffer": "^3.7"
+    "friendsofphp/php-cs-fixer": "^3.62.0",
+    "maglnet/composer-require-checker": "^4.11.0",
+    "phpstan/phpstan": "^1.11.11",
+    "phpstan/phpstan-phpunit": "^1.4.0",
+    "phpunit/phpcov": "^9.0.2",
+    "phpunit/phpunit": "^10.5.30",
+    "shipmonk/composer-dependency-analyser": "^1.7.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.62.0",
-    "maglnet/composer-require-checker": "^4.11.0",
+    "maglnet/composer-require-checker": "^4.7.1",
     "phpstan/phpstan": "^1.11.11",
     "phpstan/phpstan-phpunit": "^1.4.0",
     "phpunit/phpcov": "^9.0.2",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,6 @@
 parameters:
   phpVersion: 80100 # PHP 8.1 - Current minimal version supported
-  level: 9
+  level: max
   paths:
     - ./src
     - ./tests
@@ -9,7 +9,7 @@ parameters:
     - ./vendor/autoload.php
 
   ignoreErrors:
-    - path:    './tests/SerializerTest.php'
+    - path:    './tests/unit/SerializerTest.php'
       message: '`Parameter #2 \$class of method (.+)JsonSerializer::unserialize\(\) expects class-string, string given.`'
     - path:    './src/JsonSerializer.php'
       message: '`Method (.+)JsonSerializer::isHydratableArgument\(\) has parameter .+ with generic class ReflectionClass but does not specify its types: T`'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,42 +1,23 @@
 <?xml version="1.0"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-        backupGlobals="true"
-        backupStaticAttributes="false"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
         colors="true"
-        convertDeprecationsToExceptions="false"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        failOnEmptyTestSuite="true"
-        failOnIncomplete="true"
-        failOnRisky="true"
-        failOnWarning="true"
-        forceCoversAnnotation="false"
-        processIsolation="false"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        stopOnRisky="false"
-        timeoutForSmallTests="1"
-        timeoutForMediumTests="10"
-        timeoutForLargeTests="60"
-        verbose="false">
-  <php>
-    <ini name="error_reporting" value="E_ALL" />
-  </php>
-
-  <coverage>
+        cacheDirectory="build/.phpunit.cache"
+>
+  <source>
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+  </source>
 
   <testsuites>
-    <testsuite name="Test suite">
-      <directory>./tests</directory>
+    <testsuite name="unit">
+      <directory>./tests/unit</directory>
+    </testsuite>
+    <testsuite name="integration">
+      <directory>./tests/integration</directory>
     </testsuite>
   </testsuites>
+
 </phpunit>

--- a/src/Exception/CollectionException.php
+++ b/src/Exception/CollectionException.php
@@ -16,6 +16,4 @@ namespace Eureka\Component\Serializer\Exception;
  *
  * @author Romain Cottard
  */
-class CollectionException extends SerializerException
-{
-}
+class CollectionException extends SerializerException {}

--- a/src/Exception/SerializerException.php
+++ b/src/Exception/SerializerException.php
@@ -16,6 +16,4 @@ namespace Eureka\Component\Serializer\Exception;
  *
  * @author Romain Cottard
  */
-class SerializerException extends \Exception
-{
-}
+class SerializerException extends \Exception {}

--- a/src/JsonSerializer.php
+++ b/src/JsonSerializer.php
@@ -34,7 +34,7 @@ final class JsonSerializer
             throw new SerializerException(
                 '[CLI-10200] Cannot serialize data (json_encode failed)!',
                 10200,
-                $exception
+                $exception,
             );
         }
     }
@@ -48,14 +48,14 @@ final class JsonSerializer
     {
         try {
             /** @var array<string, mixed> $data */
-            $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+            $data = \json_decode($json, true, 512, JSON_THROW_ON_ERROR);
 
             return $this->hydrate($class, $data, $skippableParameters);
         } catch (\JsonException $exception) {
             throw new SerializerException(
                 '[CLI-10201] Cannot unserialize data (json_decode failed)!',
                 10201,
-                $exception
+                $exception,
             );
         }
     }
@@ -73,7 +73,7 @@ final class JsonSerializer
             throw new SerializerException(
                 "[CLI-10202] Given class does not exists! (class: '$class')",
                 10202,
-                $exception
+                $exception,
             );
         }
 
@@ -82,7 +82,7 @@ final class JsonSerializer
         }
 
         $parameters   = $reflection->getConstructor()->getParameters();
-        $nbParameters = count($parameters);
+        $nbParameters = \count($parameters);
 
         $orderedArguments = [];
         foreach ($parameters as $parameter) {
@@ -96,14 +96,14 @@ final class JsonSerializer
             } elseif (!$skippableParameters) {
                 throw new SerializerException(
                     "[CLI-10203] Cannot deserialize object: data '$parameterName' does not exist!",
-                    10203
+                    10203,
                 );
             }
 
             $orderedArguments[$parameter->getPosition()] = $argumentValue;
         }
 
-        ksort($orderedArguments);
+        \ksort($orderedArguments);
 
         return new $class(...$orderedArguments);
     }
@@ -115,7 +115,7 @@ final class JsonSerializer
     private function getArgumentValueFromType(
         \ReflectionParameter $parameter,
         array $data,
-        bool $skippableParameters
+        bool $skippableParameters,
     ): mixed {
         $parameterName = $parameter->getName();
         $parameterType = $parameter->getType();
@@ -133,7 +133,7 @@ final class JsonSerializer
             throw new SerializerException(
                 "[CLI-10204] Given class does not exists! (class: '$parameterName')",
                 10204,
-                $exception
+                $exception,
             );
         }
 
@@ -162,9 +162,13 @@ final class JsonSerializer
             return false;
         }
 
+        /** @var \ReflectionNamedType[] $types */
         $types = $reflectionType instanceof \ReflectionUnionType ? $reflectionType->getTypes() : [$reflectionType];
 
-        return in_array('array', array_map(fn(\ReflectionNamedType $t): string => $t->getName(), $types));
+        return \in_array(
+            'array',
+            \array_map(fn(\ReflectionNamedType $t): string => $t->getName(), $types),
+        );
     }
 
     /**
@@ -176,8 +180,8 @@ final class JsonSerializer
     private function isHydratableArgument(\ReflectionClass $parameterReflectionClass, mixed $data): bool
     {
         return (
-            in_array(\JsonSerializable::class, $parameterReflectionClass->getInterfaceNames())
-            && is_array($data)
+            \in_array(\JsonSerializable::class, $parameterReflectionClass->getInterfaceNames())
+            && \is_array($data)
         );
     }
 }

--- a/src/VO/AbstractCollection.php
+++ b/src/VO/AbstractCollection.php
@@ -51,7 +51,7 @@ class AbstractCollection implements \JsonSerializable, \ArrayAccess, \Iterator, 
      */
     public function count(): int
     {
-        return count($this->collection);
+        return \count($this->collection);
     }
 
     /**
@@ -109,7 +109,7 @@ class AbstractCollection implements \JsonSerializable, \ArrayAccess, \Iterator, 
      */
     public function valid(): bool
     {
-        return ($this->index < count($this->collection));
+        return ($this->index < \count($this->collection));
     }
 
     /**
@@ -140,7 +140,7 @@ class AbstractCollection implements \JsonSerializable, \ArrayAccess, \Iterator, 
         if ($offset === null) {
             $this->add($value);
         } else {
-            $alreadyExists             = array_key_exists($offset, $this->collection);
+            $alreadyExists             = \array_key_exists($offset, $this->collection);
             $this->collection[$offset] = $value;
 
             //~ Add mapping key if not exists
@@ -187,6 +187,6 @@ class AbstractCollection implements \JsonSerializable, \ArrayAccess, \Iterator, 
      */
     private function getNewIndex(): int
     {
-        return (!empty($this->collection)) ? array_keys($this->collection)[count($this->collection) - 1] : 0;
+        return (!empty($this->collection)) ? \array_keys($this->collection)[\count($this->collection) - 1] : 0;
     }
 }

--- a/tests/unit/CollectionTest.php
+++ b/tests/unit/CollectionTest.php
@@ -9,10 +9,10 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Serializer\Tests;
+namespace Eureka\Component\Serializer\Tests\Unit;
 
-use Eureka\Component\Serializer\Tests\VO\CollectionEntityB;
-use Eureka\Component\Serializer\Tests\VO\EntityB;
+use Eureka\Component\Serializer\Tests\Unit\VO\CollectionEntityB;
+use Eureka\Component\Serializer\Tests\Unit\VO\EntityB;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -35,7 +35,7 @@ class CollectionTest extends TestCase
 
     public function testICanCountElementInCollection(): void
     {
-        $this->assertSame(3, count($this->getCollection()));
+        $this->assertCount(3, $this->getCollection());
     }
 
     public function testICanPerformIssetOnCollectionIndex(): void
@@ -86,7 +86,7 @@ class CollectionTest extends TestCase
                 ['id' => 1, 'name' => 'name B #1'],
                 ['id' => 2, 'name' => 'name B #2'],
                 ['id' => 3, 'name' => 'name B #3'],
-            ]
+            ],
         );
     }
 }

--- a/tests/unit/SerializerTest.php
+++ b/tests/unit/SerializerTest.php
@@ -9,13 +9,13 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Serializer\Tests;
+namespace Eureka\Component\Serializer\Tests\Unit;
 
 use Eureka\Component\Serializer\Exception\SerializerException;
 use Eureka\Component\Serializer\JsonSerializer;
-use Eureka\Component\Serializer\Tests\VO\CollectionEntityB;
-use Eureka\Component\Serializer\Tests\VO\EntityA;
-use Eureka\Component\Serializer\Tests\VO\EntityB;
+use Eureka\Component\Serializer\Tests\Unit\VO\CollectionEntityB;
+use Eureka\Component\Serializer\Tests\Unit\VO\EntityA;
+use Eureka\Component\Serializer\Tests\Unit\VO\EntityB;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -57,7 +57,7 @@ class SerializerTest extends TestCase
         $data = ['id' => 1, 'name' => 'name A#1', 'other' => 'any value'];
 
         $this->expectException(SerializerException::class);
-        (new JsonSerializer())->unserialize(json_encode($data, JSON_THROW_ON_ERROR), VO\EntityA::class);
+        (new JsonSerializer())->unserialize(json_encode($data, JSON_THROW_ON_ERROR), EntityA::class);
     }
 
     /**
@@ -73,7 +73,7 @@ class SerializerTest extends TestCase
                 {
                     return "\xB1\x31";
                 }
-            }
+            },
         );
     }
 
@@ -84,7 +84,7 @@ class SerializerTest extends TestCase
     public function testASerializerExceptionIsThrownWhenIUnserializeAnInvalidJson(): void
     {
         $this->expectException(SerializerException::class);
-        (new JsonSerializer())->unserialize('[', VO\EntityA::class);
+        (new JsonSerializer())->unserialize('[', EntityA::class);
     }
 
     /**
@@ -103,7 +103,7 @@ class SerializerTest extends TestCase
      *
      * @return array<string, list<EntityA|EntityB>>
      */
-    public function provideVOForSerializationAndUnserializationTests(): array
+    public static function provideVOForSerializationAndUnserializationTests(): array
     {
         $collection = [
             ['id' => 1, 'name' => 'name B #1'],
@@ -112,9 +112,9 @@ class SerializerTest extends TestCase
         ];
 
         return [
-            'Entity A VO'                 => [new VO\EntityA(42, 'name A', null)],
-            'Entity B VO'                 => [new VO\EntityB(43, 'name B')],
-            'Entity A with Collection VO' => [new VO\EntityA(42, 'name A', new CollectionEntityB($collection))],
+            'Entity A VO'                 => [new EntityA(42, 'name A', null)],
+            'Entity B VO'                 => [new EntityB(43, 'name B')],
+            'Entity A with Collection VO' => [new EntityA(42, 'name A', new CollectionEntityB($collection))],
         ];
     }
 }

--- a/tests/unit/VO/CollectionEntityB.php
+++ b/tests/unit/VO/CollectionEntityB.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Serializer\Tests\VO;
+namespace Eureka\Component\Serializer\Tests\Unit\VO;
 
 use Eureka\Component\Serializer\Exception\CollectionException;
 use Eureka\Component\Serializer\VO\AbstractCollection;

--- a/tests/unit/VO/EntityA.php
+++ b/tests/unit/VO/EntityA.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Serializer\Tests\VO;
+namespace Eureka\Component\Serializer\Tests\Unit\VO;
 
 use Eureka\Component\Serializer\JsonSerializableTrait;
 
@@ -36,7 +36,7 @@ class EntityA implements \JsonSerializable
     public function __construct(
         int $id,
         string $name,
-        ?CollectionEntityB $listEntitiesB = null
+        ?CollectionEntityB $listEntitiesB = null,
     ) {
         $this->id            = $id;
         $this->name          = $name;

--- a/tests/unit/VO/EntityB.php
+++ b/tests/unit/VO/EntityB.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Serializer\Tests\VO;
+namespace Eureka\Component\Serializer\Tests\Unit\VO;
 
 use Eureka\Component\Serializer\JsonSerializableTrait;
 
@@ -33,7 +33,7 @@ class EntityB implements \JsonSerializable
      */
     public function __construct(
         int $id,
-        string $name
+        string $name,
     ) {
         $this->id   = $id;
         $this->name = $name;


### PR DESCRIPTION
- Now support PHP 8.3 & PHP 8.4
- Fix some code style
- Use `\` for functions from global namespace
- Replace PHPCS by php-cs-fixer
- Move unit test to subdirectory `unit/`
- Dev dependencies update
- Update CI workflow
- Update Makefile & Readme